### PR TITLE
Update Biometal US song name

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -26,15 +26,14 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Battle Garegga',
         songSource: { songName: 'Fly to the Leaden Sky', videoId: 'Szr0TSXcWok' },
-    },
-    // Note: BioMetal (JP) and BioMetal (US) share the same song name ("Dark Clouds") but these tracks are completely different from one another.
+    },    
     {
         name: 'BioMetal (JP)',
         songSource: { songName: 'Dark Clouds', videoId: 'DMhmwXbPcYg' },
     },
     {
         name: 'BioMetal (US)',
-        songSource: { songName: 'Dark Clouds', videoId: '6N3Bfm057xM' },
+        songSource: { songName: 'Twilight Zone', videoId: '6N3Bfm057xM' },
     },
     {
         name: 'Blazing Star',


### PR DESCRIPTION
This pull request updates the song information for the US version of BioMetal in the `src/data/games.ts` file to ensure accuracy.

Music data correction:

* Changed the `songName` for `BioMetal (US)` from `"Dark Clouds"` to `"Twilight Zone"` to reflect the correct track name. (`src/data/games.ts`)