### PR TITLE
Add Darius II

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -108,6 +108,24 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'CAPTAIN NEO', videoId: 'a_GP2FBiK2o' },
     },
     {
+        name: 'Darius II',
+        sortName: 'Darius 2',
+        series: Series.Darius,
+        songSource: {
+            songName: 'Olga Breeze',
+            arrangements: [
+                {
+                    source: 'Arcade',
+                    videoId: 'BpjXgNbpTqU',
+                },
+                {
+                    source: 'Mega Drive',
+                    videoId: 'X3E1UgUGf8A',
+                },
+            ],
+        },
+    },
+    {
         name: 'Darius Gaiden',
         series: Series.Darius,
         songSource: { songName: 'VISIONNERZ ~HALLUCINATED PEOPLE~', videoId: 'kG30WhHCnN4' },


### PR DESCRIPTION
This pull request adds a new game entry for "Darius II" to the `gameEntries` array in `src/data/games.ts`. The entry includes multiple arrangements of the song "Olga Breeze" from both the Arcade and Mega Drive versions. 

- Data update:
  * Added a new `GameEntry` for "Darius II" with the song "Olga Breeze" and arrangements for Arcade and Mega Drive, including their respective video IDs.