### PR TITLE
Add Salamander games and move Gradius songs to official uploads

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -281,14 +281,14 @@ const gameEntries: GameEntry[] = [
         name: 'Gradius',
         alias: 'Nemesis',
         series: Series.Gradius,
-        songSource: { songName: 'Challenger 1985', videoId: 'nYES6OmvQFQ' },
+        songSource: { songName: 'Challenger 1985', videoId: '-Fcpo6qCXMY' },
     },
     {
         name: 'Gradius II',
         alias: 'Vulcan Venture',
         sortName: 'Gradius 2',
         series: Series.Gradius,
-        songSource: { songName: 'Burning Heat', videoId: 'FLc1msji0_w' },
+        songSource: { songName: 'Burning Heat', videoId: '76kJEPGvvMg' },
     },
     {
         name: 'Gradius III',
@@ -819,6 +819,22 @@ const gameEntries: GameEntry[] = [
         name: 'Sagaia (Game Boy)',
         series: Series.Darius,
         songSource: { songName: 'Cosmic Air Way', videoId: 'ekMGtD9cDhQ' },
+    },
+    {
+        name: 'Salamander',
+        alias: 'Life Force',
+        series: Series.Gradius,        
+        songSource: { songName: 'Power of Anger', videoId: 'gle0JLhaRxw' },
+    },
+    {
+        name: 'Salamander 2',
+        series: Series.Gradius,        
+        songSource: { songName: 'Silver Wings Again', videoId: 'Y0CFKk8WDTM' },
+    },
+    {
+        name: 'Salamander III',
+        series: Series.Gradius,        
+        songSource: { songName: 'Courage of Pride', videoId: '6VRkKpoJADc' },
     },
     {
         name: 'Shienryu',


### PR DESCRIPTION
This pull request updates the `gameEntries` array in `src/data/games.ts` with improvements to Gradius series song sources and adds new entries for the Salamander sub-series. The main changes are focused on updating video IDs for accuracy and expanding the game data.

**Gradius series improvements:**

* Updated the `songSource.videoId` for Gradius from `'nYES6OmvQFQ'` to `'-Fcpo6qCXMY'` to use official soundtrack upload.
* Updated the `songSource.videoId` for Gradius II from `'FLc1msji0_w'` to `'76kJEPGvvMg'` to use official soundtrack upload.

**Salamander series additions:**

* Added new entries for `Salamander` (Life Force), `Salamander 2`, and `Salamander III` to the Gradius series, each with their respective `songSource` and video IDs.