### PR TITLE
Add Ibara tracks

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -351,6 +351,11 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Stage 1', videoId: 'lHGdbyX82TE' },
     },
     {
+        name: 'Ibara',
+        series: Series.Ibara,
+        songSource: { songName: 'Show Time', videoId: 'T65Zmc6iWCc' },
+    },
+    {
         name: 'Ikaruga',
         songSource: { songName: 'Ideal', videoId: 'fAn6XxsDDTI' },
     },
@@ -576,6 +581,11 @@ const gameEntries: GameEntry[] = [
     {
         name: 'PD Ultraman Invader',
         songSource: { songName: 'Ultraman', videoId: 'UD8ILryBKPY' },
+    },
+    {
+        name: 'Pink Sweets: Ibara Sorekara',
+        series: Series.Ibara,
+        songSource: { songName: 'Mama! Ora va!', videoId: '48L8QKOFehc' },
     },
     {
         name: 'Platypus',

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export enum Series {
     Dodonpachi = 'Dodonpachi',
     Espgaluda = 'Espgaluda',
     Gradius = 'Gradius',
+    Ibara = 'Ibara',
     Macross = 'Macross',
     RType = 'R-Type',
     Raiden = 'Raiden',


### PR DESCRIPTION
This pull request adds support for the Ibara game series by introducing new entries and updating the series enumeration. The main changes are the addition of two games from the Ibara series, each with their own song source, and the inclusion of the `Ibara` value in the `Series` enum.

**Support for the Ibara series:**

* Added `Ibara` to the `Series` enum in `src/types.ts` to allow categorization of games under the Ibara series.

**New game entries:**

* Added a new game entry for `Ibara` with its associated song "Show Time" in `src/data/games.ts`.
* Added a new game entry for `Pink Sweets: Ibara Sorekara` with its associated song "Mama! Ora va!" in `src/data/games.ts`.