### PR TITLE
Add some more games and perform metadata cleanup

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -265,6 +265,11 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Stage 1, 3-2', videoId: '69wGmxanW20' },
     },
     {
+        name: 'FixEight',
+        series: Series.OutZone,
+        songSource: { songName: 'Fixer', videoId: 'pyefFS8SwiA', startTime: 10, endTime: 119 },
+    },
+    {
         name: 'Flying Shark',
         series: Series.FlyingShark,
         alias: 'Sky Shark',
@@ -349,6 +354,17 @@ const gameEntries: GameEntry[] = [
         name: 'Gradius: The Interstellar Assault',
         series: Series.Gradius,
         songSource: { songName: 'The Chase, A Ruins, Toadstool', videoId: '05L6GWxUugg', startTime: 103, endTime: 326 },
+    },
+    {
+        name: 'Grind Stormer',
+        alias: 'V・V',
+        songSource: {
+            songName: 'Wonderful Dreamer',
+            arrangements: [
+                { source: 'Arcade', videoId: 'Qe4Fy2oYehw' },
+                { source: 'Mega Drive', videoId: '3Cg7Tgp-d7k' },
+            ],
+        },
     },
     {
         name: 'Gun Frontier',
@@ -537,6 +553,10 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Take off ~ Born to be free', videoId: 'GBS6KfJRyIg' },
     },
     {
+        name: 'Muchi Muchi Pork!',
+        songSource: { songName: 'Doki Doki in the Sky', videoId: 'iTb0FEaqsv4' },
+    },
+    {
         name: 'M.U.S.H.A.: Metallic Uniframe Super Hybrid Armor',
         alias: 'Musha Aleste: Full Metal Fighter Ellinor',
         sortName: 'MUSHA',
@@ -570,6 +590,11 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Natsuki Chronicles',
         songSource: { songName: 'Hopeful Morning Glow', videoId: 'HuzP7m6Us28' },
+    },
+    {
+        name: 'Out Zone',
+        series: Series.OutZone,
+        songSource: { songName: 'To The Earth', videoId: 'zfefU4y8P00' },
     },
     {
         name: 'Parodius',
@@ -835,6 +860,10 @@ const gameEntries: GameEntry[] = [
         name: 'Raiden Fighters Jet',
         series: Series.Raiden,
         songSource: { songName: 'Simulation Level 01 (Launch Base)', videoId: 'C4DFwgSpO00' },
+    },
+    {
+        name: 'Rainchaser',
+        songSource: { songName: 'Rapid Approach', videoId: 'EXL2ur8D7iM', startTime: 323, endTime: 568 },
     },
     {
         name: 'RayForce',
@@ -1183,6 +1212,8 @@ const gameEntries: GameEntry[] = [
     },
     {
         name: 'Truxton',
+        series: Series.Truxton,
+        alias: 'Tatsujin',
         songSource: {
             songName: 'Brave Man, Far Away',
             arrangements: [
@@ -1203,6 +1234,7 @@ const gameEntries: GameEntry[] = [
     },
     {
         name: 'Truxton II',
+        alias: 'Tatsujin Oh',
         songSource: { songName: 'Live in Future', videoId: 'xgxFHJZrAfc' },
     },
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,12 +10,14 @@ export enum Series {
     Gradius = 'Gradius',
     Ibara = 'Ibara',
     Macross = 'Macross',
+    OutZone = 'Out Zone',
     RType = 'R-Type',
     Raiden = 'Raiden',
     Strikers1945 = 'Strikers 1945',
     SonicWings = 'Sonic Wings',
     SpaceInvaders = 'Space Invaders',
     Touhou = 'Touhou Project',
+    Truxton = 'Truxton',
     Zeal = 'Zeal',
 }
 


### PR DESCRIPTION
This pull request adds several new game entries and enhances existing ones in the `src/data/games.ts` file, while also updating the `Series` enum in `src/types.ts` to support the new entries. The changes primarily focus on expanding the database of games and improving metadata for better categorization and searchability.

**New game entries and series enhancements:**

*Added new games and expanded series support:*
- Added new game entries for `FixEight`, `Grind Stormer`, `Muchi Muchi Pork!`, `Out Zone`, and `Rainchaser`, each with corresponding song information and, where appropriate, series associations and arrangement details. [[1]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R267-R271) [[2]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R358-R368) [[3]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R555-R558) [[4]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R594-R598) [[5]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R864-R867)
- Added new series values `OutZone` and `Truxton` to the `Series` enum in `src/types.ts` to support the new and updated game entries.

*Improved metadata for existing games:*
- Added the `series` property and an alias (`Tatsujin`) to the `Truxton` entry, and added an alias (`Tatsujin Oh`) to `Truxton II` for better search and categorization. [[1]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R1215-R1216) [[2]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R1237)…ta cleanup