### PR TITLE
Add more games, add Ibara Black Label stage 1 song

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -78,6 +78,20 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Retro Blitz', videoId: 'o-SVBG4IYSY' },
     },
     {
+        name: 'Air Duel',
+        songSource: { songName: 'Stage 1', videoId: '8WsKeA4v01U' },
+    },
+    {
+        name: 'Air Assault',
+        alias: 'Fire Barrel',
+        sortName: 'Air Duel 2',
+        songSource: { songName: 'Stage 1', videoId: 'SF4fQlJ58V8' },
+    },
+    {
+        name: 'Air Gallet',
+        songSource: { songName: 'Stage 1', videoId: 'YbM2D2_QJMY' },
+    },
+    {
         name: 'Air Zonk',
         songSource: { songName: 'Aqua Base stage', videoId: '9IJcqceH3CM' },
     },
@@ -129,6 +143,11 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Blue Revolver',
         songSource: { songName: 'Qygenomics', videoId: 'dTbpYrrSRPY' },
+    },
+    {
+        name: 'Carrier Air Wing',
+        alias: 'U.S. Navy',
+        songSource: { songName: 'Mission 1', videoId: 'xBNq6tCJVcE' },
     },
     {
         name: 'Castle of Shikigami',
@@ -200,9 +219,20 @@ const gameEntries: GameEntry[] = [
         },
     },
     {
+        name: 'Darius Force',
+        alias: 'Super Nova',
+        series: Series.Darius,
+        songSource: { songName: 'A King', videoId: 'mtEtEeEfo0Y' },
+    },
+    {
         name: 'Darius Gaiden',
         series: Series.Darius,
         songSource: { songName: 'Visionnerz ~Hallucinated People~', videoId: 'kG30WhHCnN4' },
+    },
+    {
+        name: 'Darius Twin',
+        series: Series.Darius,
+        songSource: { songName: 'A Flasing Dual Hawk', videoId: '0wvJb9bgdCk' },
     },
     {
         name: 'Dariusburst',
@@ -331,6 +361,28 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Stage 1, 3-2', videoId: '69wGmxanW20' },
     },
     {
+        name: 'Fever SOS',
+        alias: 'Dangun Feveron',
+        songSource: { songName: 'Dancing Bomber', videoId: 'FOXIDqkCXaY' },
+    },
+    {
+        name: 'Fighter & Attacker',
+        alias: 'F/A',
+        songSource: { songName: 'Desert Storm', videoId: 'H23ZWktzasc' },
+    },
+    {
+        name: 'Fire Shark',
+        alias: 'Same! Same! Same!',
+        series: Series.FlyingShark,
+        songSource: {
+            songName: 'Fire Shark',
+            arrangements: [
+                { source: 'Arcade', videoId: 'EBIn673qfHM' },
+                { source: 'Mega Drive', videoId: 'QDSzs97Mhzw' },
+            ],
+        },
+    },
+    {
         name: 'FixEight',
         series: Series.OutZone,
         songSource: { songName: 'Fixer', videoId: 'pyefFS8SwiA', startTime: 10, endTime: 119 },
@@ -353,19 +405,6 @@ const gameEntries: GameEntry[] = [
         series: Series.FlyingShark,
         alias: 'Sky Shark',
         songSource: { songName: 'Stage 1', videoId: 'yxsKzGZ8WHg' },
-    },
-    {
-        name: 'Fire Shark',
-        alias: 'Same! Same! Same!',
-        series: Series.FlyingShark,
-        sortName: 'Flying Shark 2',
-        songSource: {
-            songName: 'Fire Shark',
-            arrangements: [
-                { source: 'Arcade', videoId: 'EBIn673qfHM' },
-                { source: 'Mega Drive', videoId: 'QDSzs97Mhzw' },
-            ],
-        },
     },
     {
         name: 'G-Darius',
@@ -474,7 +513,10 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Ibara',
         series: Series.Ibara,
-        songSource: { songName: 'Show Time', videoId: 'T65Zmc6iWCc' },
+        songSource: [
+            { songName: 'Show Time', videoId: 'T65Zmc6iWCc' },
+            { songName: 'Bonds of Steel', videoId: 'XgSMvKTaMXU' },
+        ] ,
     },
     {
         name: 'Ikaruga',
@@ -665,8 +707,16 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Setting Off Together', videoId: '2qoyJbieTOc' },
     },
     {
+        name: 'Mystic Riders',
+        songSource: { songName: 'Midnight Town', videoId: 'GjcgS4o0HFg' },
+    },
+    {
         name: 'Natsuki Chronicles',
         songSource: { songName: 'Hopeful Morning Glow', videoId: 'HuzP7m6Us28' },
+    },
+    {
+        name: 'NebulasRay',
+        songSource: { songName: 'Exeo', videoId: 'PyHmUSQaNYM' },
     },
     {
         name: 'Out Zone',


### PR DESCRIPTION
This pull request expands and updates the `gameEntries` array in `src/data/games.ts` by adding new games, updating song sources, and making minor adjustments to existing entries. The main focus is on increasing the completeness and accuracy of the game and soundtrack data.

**Additions and updates to game entries:**

*New game entries:*
- Added several new games, including `Air Duel`, `Air Assault` (with alias `Fire Barrel`), `Air Gallet`, `Carrier Air Wing` (with alias `U.S. Navy`), `Darius Force` (alias `Super Nova`), `Darius Twin`, `Fever SOS` (alias `Dangun Feveron`), `Fighter & Attacker` (alias `F/A`), `Mystic Riders`, and `NebulasRay`, each with their corresponding song sources. [[1]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R80-R93) [[2]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R147-R151) [[3]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R221-R236) [[4]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R363-R384) [[5]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R709-R720)

*Song source enhancements:*
- Updated the `Ibara` entry to include an additional song, now listing both "Show Time" and "Bonds of Steel" as song sources.

*Entry corrections and deduplication:*
- Removed sorting from `Fire Shark` [[1]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R363-R384) [[2]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29L357-L369)