### PR TITLE
Add anime-themed games

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -161,6 +161,11 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Qygenomics', videoId: 'dTbpYrrSRPY' },
     },
     {
+        name: 'Bullet Soul',
+        alias: 'Bullet Soul: Infinite Burst',
+        songSource: { songName: 'Relentless Force', videoId: 'ahK-7dPcI6w' },
+    },
+    {
         name: 'Carrier Air Wing',
         alias: 'U.S. Navy',
         songSource: { songName: 'Mission 1', videoId: 'xBNq6tCJVcE' },
@@ -186,6 +191,11 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Cho Ren Sha 68K',
         songSource: { songName: 'Planet the E.A.R.T.H', videoId: 'aT3z4k1BlDg' },
+    },
+    {
+        name: 'Cosmo Dreamer',
+        series: Series.Dreamer,
+        songSource: { songName: 'InstaVista', videoId: 'A-SqHyJa-jU' },
     },
     {
         name: 'Cotton: Fantastic Night Dreams',
@@ -711,6 +721,11 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Jack to the Metro', videoId: 'HAGArKEC_M8' },
     },
     {
+        name: 'Like Dreamer',
+        series: Series.Dreamer,
+        songSource: { songName: 'Cat Mischief', videoId: '1iEJRCaanBY' },
+    },
+    {
         name: 'Lords of Thunder',
         songSource: [
             {
@@ -967,6 +982,10 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Pulstar',
         songSource: { songName: 'Front Line on the Earth', videoId: 'IexMUkiPg-M' },
+    },
+    {
+        name: 'Q-Side',
+        songSource: { songName: 'Q-Side', videoId: 'THAVdbVqh8U' },
     },
     {
         name: 'QP Shooting - Dangerous!!',

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export enum Series {
     DanmakuUnlimited = 'Danmaku Unlimited',
     Darius = 'Darius',
     Dodonpachi = 'Dodonpachi',
+    Dreamer = 'Dreamer',
     Espgaluda = 'Espgaluda',
     FantasyZone = 'Fantasy Zone',
     FlyingShark = 'Flying Shark',


### PR DESCRIPTION
This pull request adds several new game entries and introduces a new series to the data model. The main focus is on adding the Hatsune Miku shmup and the rest is just here because may as well add some more while I'm going

**Game data additions and updates:**

* Added new games to `gameEntries` in `src/data/games.ts`, including:
  - "Bullet Soul" (with alias "Bullet Soul: Infinite Burst")
  - "Cosmo Dreamer" (with `series: Series.Dreamer`)
  - "Like Dreamer" (with `series: Series.Dreamer`)
  - "Q-Side"

**Type system update:**

* Added a new enum value `Dreamer` to the `Series` enum in `src/types.ts` to support the new series for relevant games.