### PR TITLE
Add songs to reach 250 game tracks

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -421,7 +421,7 @@ const gameEntries: GameEntry[] = [
             songName: 'First Encounter',
             arrangements: [
                 { source: 'Arcade', videoId: 'GU4z00gXU_E' },
-                { source: 'Super Nintendo', videoId: 'UquBgibh4h4' },
+                { source: 'Super Nintendo', videoId: '2LLrf6Vk-Dk' },
             ],
         },
     },


### PR DESCRIPTION
This pull request adds several new game entries to the `gameEntries` array in `src/data/games.ts`, expanding the library of games and their associated music tracks. The additions include both classic and lesser-known shoot-'em-up titles, with some entries featuring multiple arrangements or platform versions of their soundtracks.

New game entries and song sources:

**Games with multiple soundtrack arrangements:**

* Added `Argus` with "BGM 1" and arrangements for both Arcade and NES versions.
* Added `Earth Defense Force` (also known as "Super Earth Defense Force") with "First Encounter" and arrangements for Arcade and Super Nintendo.

**Single soundtrack additions:**

* Added `Chopper 1` with the song "Dream of Chopper".
* Added `Halley's Comet` with the song "Ed1986", specifying a start and end time for the track.
* Added `Omega Fighter` with the song "Mission 1", including specific start and end times.