### PR TITLE
Replace Mega Drive Truxton with version that includes 'Brave Man' intro

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -2159,7 +2159,8 @@ const gameEntries: GameEntry[] = [
                 },
                 {
                     source: 'Mega Drive',
-                    videoId: 'rWD0BEHbl2I',
+                    videoId: 'PwuBChnj7UI',
+                    endTime: 129,
                 },
                 {
                     source: 'PC Engine',


### PR DESCRIPTION
This pull request makes a small update to the `src/data/games.ts` file by changing the `videoId` for the 'Mega Drive' source and adding an `endTime` property to the same entry.