### PR TITLE
Add remaining Touhou songs and update video IDs

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -2050,19 +2050,55 @@ const gameEntries: GameEntry[] = [
             ] },
     },
     {
+        name: 'Touhou 1: Highly Responsive to Prayers',
+        series: Series.Touhou,
+        songSource: { songName: 'Eternal Shrine Maiden', videoId: 'pixjDAEADYY' },
+    },
+    {
+        name: 'Touhou 2: Story of Eastern Wonderland',
+        series: Series.Touhou,
+        songSource: { songName: 'Hakurei ~ Eastern Wind', videoId: '-1qf-DCu9ZM' },
+    },
+    {
+        name: 'Touhou 3: Phantasmagoria of Dim. Dream',
+        series: Series.Touhou,
+        songSource: [
+            { songName: 'Eastern Mystical Love Consultation', videoId: 'mUJm5TLnE80' },
+            { songName: 'Reincarnation', videoId: 'l3jJnQRtAUk' },
+            { songName: 'Dim. Dream', videoId: 'U_RQnQ7aQU4' },
+            { songName: 'Tabula rasa ~ The Empty Girl', videoId: '_bqoAqRoZx0' },
+            { songName: 'Manaical Princess', videoId: 'iRjWLLI0K7U' },
+            { songName: 'Vanishing Dream ~ Lost Dream', videoId: 'Q8wO4plpXvA' },
+            { songName: 'Visionary Game ~ Dream War', videoId: 'FLOqCMC1bfc' },
+        ],
+    },
+    {
+        name: 'Touhou 4: Lotus Land Story',
+        series: Series.Touhou,
+        songSource: [
+            { songName: 'Witching Dream', videoId: 'EK8BsPAyXRE' },
+            { songName: "Selene's Light", videoId: '0Dp-5Q6POXU' },
+        ],
+    },
+    {
+        name: 'Touhou 5: Mystic Square',
+        series: Series.Touhou,
+        songSource: { songName: 'Dream Express', videoId: 'Ylzq72GG_cM' },
+    },
+    {
         name: 'Touhou 6: Embodiment of Scarlet Devil',
         series: Series.Touhou,
-        songSource: { songName: 'A Soul as Red as a Ground Cherry', videoId: 'nazi6JmAV_c' },
+        songSource: { songName: 'A Soul as Red as a Ground Cherry', videoId: '2-zBXJKw5IQ' },
     },
     {
         name: 'Touhou 7: Perfect Cherry Blossom',
         series: Series.Touhou,
-        songSource: { songName: 'Paradise ~ Deep Mountain', videoId: 'hzTtdlTAapw' },
+        songSource: { songName: 'Paradise ~ Deep Mountain', videoId: 'vkX5OpV_cRs' },
     },
     {
         name: 'Touhou 8: Imperishable Night',
         series: Series.Touhou,
-        songSource: { songName: 'Illusionary Night ~ Ghostly Eyes', videoId: 'buarznoa7ms' },
+        songSource: { songName: 'Illusionary Night ~ Ghostly Eyes', videoId: 'inJ4ObsrNc' },
     },
     {
         name: 'Touhou 9: Phantasmagoria of Flower View',

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -2098,7 +2098,7 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Touhou 8: Imperishable Night',
         series: Series.Touhou,
-        songSource: { songName: 'Illusionary Night ~ Ghostly Eyes', videoId: 'inJ4ObsrNc' },
+        songSource: { songName: 'Illusionary Night ~ Ghostly Eyes', videoId: 'jinJ4ObsrNc' },
     },
     {
         name: 'Touhou 9: Phantasmagoria of Flower View',

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -2066,7 +2066,7 @@ const gameEntries: GameEntry[] = [
             { songName: 'Eastern Mystical Love Consultation', videoId: 'mUJm5TLnE80' },
             { songName: 'Reincarnation', videoId: 'l3jJnQRtAUk' },
             { songName: 'Dim. Dream', videoId: 'U_RQnQ7aQU4' },
-            { songName: 'Tabula rasa ~ The Empty Girl', videoId: '_bqoAqRoZx0' },
+            { songName: 'Tabula rasa ~ The Empty Girl', videoId: 'VJ1EAnTUQq0' },
             { songName: 'Manaical Princess', videoId: 'iRjWLLI0K7U' },
             { songName: 'Vanishing Dream ~ Lost Dream', videoId: 'Q8wO4plpXvA' },
             { songName: 'Visionary Game ~ Dream War', videoId: 'FLOqCMC1bfc' },


### PR DESCRIPTION
This pull request expands the Touhou game entries in `src/data/games.ts` by adding the first five games of the series, each with their respective music tracks, and updates the song video links for Touhou 6, 7, and 8 to more accurate or preferred versions.

Additions to Touhou game entries:

* Added entries for `Touhou 1: Highly Responsive to Prayers`, `Touhou 2: Story of Eastern Wonderland`, `Touhou 3: Phantasmagoria of Dim. Dream` (with multiple songs), `Touhou 4: Lotus Land Story` (with multiple songs), and `Touhou 5: Mystic Square`, each with associated music tracks and YouTube video IDs.

Updates to existing Touhou entries:

* Updated the `songSource.videoId` for `Touhou 6: Embodiment of Scarlet Devil`, `Touhou 7: Perfect Cherry Blossom`, and `Touhou 8: Imperishable Night` to new YouTube video IDs, likely reflecting better or more official sources.