### PR TITLE
Add titles from Nintendo systems

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -206,8 +206,10 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Blazeon',
         songSource: {
-            songName: 'Stage 1',
+            songName: 'Optimistic Departure',
             arrangements: [
+                { source: 'Arcade', videoId: 'SaLxZSK4FyA' },
+                { source: 'SNES', videoId: 'qHKLGLmfuew' },
             ],
         },
     },

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -278,6 +278,16 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'InstaVista', videoId: 'A-SqHyJa-jU' },
     },
     {
+        name: 'Cosmo Gang: The Video',
+        songSource: {
+            songName: 'Alignment (Planet)',
+            arrangements: [
+                { source: 'Arcade', videoId: 'Z9ZFeHa-pns' },
+                { source: 'Super Nintendo', videoId: '2ZALXraGc_A', startTime: 4, endTime: 17 },
+            ],
+        },
+    },
+    {
         name: 'Cotton: Fantastic Night Dreams',
         alias: 'Cotton Reboot!',
         sortName: 'Cotton 1',
@@ -803,7 +813,7 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Sand Storm',
             arrangements: [
                 { source: 'Arcade', videoId: 'NyQzfqNIKTI' },
-                { source: 'SNES', videoId: 'd_w43Ew_-jI' },
+                { source: 'Super Nintendo', videoId: 'd_w43Ew_-jI' },
             ],
         },
     },
@@ -1552,7 +1562,7 @@ const gameEntries: GameEntry[] = [
                     videoId: 'vtOHNnZKlCI',
                 },
                 {
-                    source: 'SNES',
+                    source: 'Super Nintendo',
                     videoId: 'zSqXP-ITmv8',
                 },
                 {

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -2455,6 +2455,10 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Main BGM', videoId: 'Y6gEyApB4b4' },
     },
     {
+        name: 'Wolflame',
+        songSource: { songName: 'Stage 1, 4', videoId: 'PStagEoZemM' },
+    },
+    {
         name: 'X Multiply',
         songSource: { songName: 'Into the Human Body', videoId: 'MwwduquIWIo' },
     },

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -1259,11 +1259,7 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Nanostray 2',
         series: Series.Nanostray,
-        songSource: [
-            { songName: 'Mitsurin Jungle', videoId: '6Dgv4FfGB0g' },
-            { songName: 'Mokuzu Depths', videoId: 'hqkweo5_UtA' },
-            { songName: 'Sunahara Desert', videoId: 'l66Oxr49iLQ' },
-        ],
+        songSource: { songName: 'Tappeki Dock', videoId: 'x3qpC_4mO_U' },
     },
     {
         name: 'Natsuki Chronicles',

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -82,6 +82,16 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Internal Combat', videoId: 'tXxLHnwg7ec' },
     },
     {
+        name: 'Acrobat Mission',
+        songSource: {
+            songName: 'Mission 1',
+            arrangements: [
+                { source: 'Arcade', videoId: '9NpFVWZQYXk' },
+                { source: 'SNES', videoId: 'Z7xuMFm732M' },
+            ],
+        },
+    },
+    {
         name: 'Air Duel',
         songSource: { songName: 'Stage 1', videoId: '8WsKeA4v01U' },
     },
@@ -192,6 +202,14 @@ const gameEntries: GameEntry[] = [
     {
         name: 'BioMetal (US)',
         songSource: { songName: 'Twilight Zone', videoId: '6N3Bfm057xM' },
+    },
+    {
+        name: 'Blazeon',
+        songSource: {
+            songName: 'Stage 1',
+            arrangements: [
+            ],
+        },
     },
     {
         name: 'Blazing Lazers',
@@ -1001,6 +1019,10 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Final Hour', videoId: 'Ij44absscCw' },
     },
     {
+        name: 'Karous',
+        songSource: { songName: '1000 clouds', videoId: 'v8RbFJ2wnn8' },
+    },
+    {
         name: 'Ketsui',
         songSource: { songName: 'Interception - Noisy Town', videoId: 'z472pIce5CY' },
     },
@@ -1164,6 +1186,19 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Game BGM 1', videoId: 'rX-6X3NIYX4' },
     },
     {
+        name: 'Metal Torrent',
+        songSource: [
+            {
+                songName: 'Accipiter Theme',
+                videoId: 'sXVc2n6OOnY',
+            },
+            {
+                songName: 'Bateleur Theme',
+                videoId: '1mEhU4tA8t8',
+            },
+        ],
+    },
+    {
         name: 'Metamor Jupiter',
         songSource: { songName: 'Stage 1', videoId: 'npoIjq_2b9M' },
     },
@@ -1283,6 +1318,20 @@ const gameEntries: GameEntry[] = [
     {
         name: 'PD Ultraman Invader',
         songSource: { songName: 'Ultraman', videoId: 'UD8ILryBKPY' },
+    },
+    {
+        name: 'Phalanx (Sharp X68000)',
+        songSource: { songName: 'Assault', videoId: '9n8sXo2l7j0' },
+    },
+    {
+        name: 'Phalanx (SNES/GBA)',
+        songSource: {
+            songName: 'Assault',
+            arrangements: [
+                { source: 'SNES', videoId: 'QmQIEjLHVIQ' },
+                { source: 'GBA', videoId: 'u4vtCzjp4gg' },
+            ],
+        },
     },
     {
         name: 'Pink Sweets: Ibara Sorekara',

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -1248,6 +1248,24 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Midnight Town', videoId: 'GjcgS4o0HFg' },
     },
     {
+        name: 'Nanostray',
+        series: Series.Nanostray,
+        songSource: [
+            { songName: 'Mitsurin Jungle', videoId: '6Dgv4FfGB0g' },
+            { songName: 'Mokuzu Depths', videoId: 'hqkweo5_UtA' },
+            { songName: 'Sunahara Desert', videoId: 'l66Oxr49iLQ' },
+        ],
+    },
+    {
+        name: 'Nanostray 2',
+        series: Series.Nanostray,
+        songSource: [
+            { songName: 'Mitsurin Jungle', videoId: '6Dgv4FfGB0g' },
+            { songName: 'Mokuzu Depths', videoId: 'hqkweo5_UtA' },
+            { songName: 'Sunahara Desert', videoId: 'l66Oxr49iLQ' },
+        ],
+    },
+    {
         name: 'Natsuki Chronicles',
         songSource: { songName: 'Hopeful Morning Glow', videoId: 'HuzP7m6Us28' },
     },

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -1323,7 +1323,7 @@ const gameEntries: GameEntry[] = [
     },
     {
         name: 'Phalanx (Sharp X68000)',
-        songSource: { songName: 'Assault', videoId: '9n8sXo2l7j0' },
+        songSource: { songName: 'Assault', videoId: 'kwTLlUo9G14' },
     },
     {
         name: 'Phalanx (SNES/GBA)',

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export enum Series {
     Ibara = 'Ibara',
     Macross = 'Macross',
     Mahou = 'Mahou',
+    Nanostray = 'Nanostray',
     OutZone = 'Out Zone',
     RType = 'R-Type',
     Raiden = 'Raiden',


### PR DESCRIPTION
This pull request adds several new game entries and music tracks to the `gameEntries` array in `src/data/games.ts`, updates some naming conventions for consistency, and introduces a new series to the `Series` enum in `src/types.ts`. The main focus is expanding the database of games and their associated music, especially for games with multiple arrangements or versions.

**Additions and data expansion:**

* Added new games with their respective music tracks, including `Acrobat Mission`, `Blazeon`, `Cosmo Gang: The Video`, `Karous`, `Metal Torrent`, `Nanostray`, `Nanostray 2`, `Phalanx (Sharp X68000)`, `Phalanx (SNES/GBA)`, and `Wolflame`. Some entries include multiple arrangements or tracks. [[1]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R84-R93) [[2]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R206-R215) [[3]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R280-R289) [[4]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R1033-R1036) [[5]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R1200-R1212) [[6]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R1260-R1273) [[7]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R1348-R1361) [[8]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R2457-R2460)

**Naming and consistency improvements:**

* Standardized the platform naming from `SNES` to `Super Nintendo` in arrangement sources for consistency across entries. [[1]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29L786-R816) [[2]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29L1490-R1565)

**Type and enum updates:**

* Added `Nanostray` to the `Series` enum in `src/types.ts` to support the new `Nanostray` and `Nanostray 2` entries.