### PR TITLE
Prevent song data being displayed via browser or OS level mechanisms

### DIFF
--- a/src/components/YouTubePlayer.vue
+++ b/src/components/YouTubePlayer.vue
@@ -129,6 +129,9 @@ function scheduleStop() {
 
 onUnmounted(() => {
     clearStopTimer();
+    if ('mediaSession' in navigator) {
+        navigator.mediaSession.metadata = null;
+    }
 });
 
 const currentQuote = computed(() => props.quote ?? '');
@@ -155,6 +158,20 @@ watch(() => props.videoId, () => {
     }
 }, { flush: 'post' });
 
+// Override the OS media overlay (e.g. Windows volume panel) with generic
+// metadata so the YouTube video title and thumbnail are not exposed while
+// the answer is still hidden.  Browsers route OS-level SMTC / media-key
+// notifications through the top-level page's mediaSession, so setting it
+// here shadows whatever YouTube's iframe reports.
+function setGenericMediaSession() {
+    if ('mediaSession' in navigator) {
+        navigator.mediaSession.metadata = new MediaMetadata({
+            title: 'Now Playing…',
+            artist: 'Stage 1 Quiz',
+        });
+    }
+}
+
 function startAudio() {
     // Seek back to the configured start time before unmuting, so the
     // listener always hears the track from the beginning regardless of
@@ -167,6 +184,7 @@ function startAudio() {
     audioUnlocked.value = true;
     emit('audioUnlocked');
     scheduleStop();
+    setGenericMediaSession();
 }
 
 const restartSpinning = ref(false);

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,14 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Permissions-Policy",
+          "value": "mediasession=self"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This pull request overrides the operating system's media metadata when playing YouTube videos in the `YouTubePlayer.vue` component. It ensures that the actual YouTube video title and thumbnail are not exposed in OS-level media overlays (such as the Windows volume panel) while the answer is hidden. The implementation uses the Media Session API to set generic metadata and cleans it up when the component unmounts.

**Privacy improvements for media metadata:**

* Added a `setGenericMediaSession` function that sets generic media metadata (title and artist) using the Media Session API to prevent exposure of the YouTube video title and thumbnail in OS-level media overlays. This function is called when audio playback starts. [[1]](diffhunk://#diff-0d3fb4df3ce33fd628708f61dced598e3087bf9e78e43da159e40c23960df3bdR161-R174) [[2]](diffhunk://#diff-0d3fb4df3ce33fd628708f61dced598e3087bf9e78e43da159e40c23960df3bdR187)
* Cleared the `mediaSession.metadata` when the component unmounts to avoid stale metadata lingering after the component is destroyed.