### PR TITLE
Add Gyruss songs and fix game listing

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -2170,6 +2170,7 @@ const gameEntries: GameEntry[] = [
     },
     {
         name: 'Tempest 2000',
+        alias: [ 'Tempest 3000', 'Tempest 4000' ],
         songSource: { songName: "Mind's Eye", videoId: 'ZdjlSWipbWM' },
     },
     {

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -985,11 +985,12 @@ const gameEntries: GameEntry[] = [
     },
     {
         name: 'Gyruss',
-        songSource: { songName: 'Stage 1', videoId: 'mzCGqpUVxJ4' },
-    },
-    {
-        name: 'Gyruss (NES)',
-        songSource: { songName: 'Stage 1', videoId: 'e9zhVYuCCRI' },
+        songSource: { songName: 'Main Theme',
+            arrangements: [
+                { source: 'Arcade', videoId: 'PBzqbQSHhU0' },
+                { source: 'NES', videoId: 'quPLRVaEOns' },
+            ],
+        },
     },
     {
         name: "Halley's Comet",

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -984,6 +984,14 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Falling Cherry Blossoms', videoId: 'EWYuTxCV11U' },
     },
     {
+        name: 'Gyruss',
+        songSource: { songName: 'Stage 1', videoId: 'mzCGqpUVxJ4' },
+    },
+    {
+        name: 'Gyruss (NES)',
+        songSource: { songName: 'Stage 1', videoId: 'e9zhVYuCCRI' },
+    },
+    {
         name: "Halley's Comet",
         songSource: { songName: 'Ed1986', videoId: 'QliWHAxJ8V4', startTime: 2, endTime: 146 },
     },

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -92,6 +92,18 @@ const gameEntries: GameEntry[] = [
         },
     },
     {
+        name: 'Air Buster',
+        alias: 'Aero Blasters',
+        songSource: {
+            songName: 'Seaside Front',
+            arrangements: [
+                { source: 'Arcade', videoId: '9NpFVWZQYXk' },
+                { source: 'Mega Drive', videoId: '8ipAllxpgMs' },
+                { source: 'PC Engine', videoId: 'a31IUDPILV0' },
+            ],
+        },
+    },
+    {
         name: 'Air Duel',
         songSource: { songName: 'Stage 1', videoId: '8WsKeA4v01U' },
     },
@@ -108,6 +120,10 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Air Zonk',
         songSource: { songName: 'Aqua Base stage', videoId: '9IJcqceH3CM' },
+    },
+    {
+        name: 'Aka to Blue',
+        songSource: { songName: 'RED7029', videoId: 'Za0F2ZwbjbM' },
     },
     {
         name: 'Akai Katana',
@@ -657,6 +673,13 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Ex-Calibre',
         songSource: { songName: "Cruisin'", videoId: 'ddJJ_geDcYU' },
+    },
+    {
+        name: 'Exceed 3rd - Jade Penetrate',
+        alias: 'Exceed 3rd - Jade Penetrate - Black Package',
+        songSource: {
+            songName: 'Wind Wings', videoId: 'gUZVglcDQXE',
+        },
     },
     {
         name: 'Explosive Breaker',
@@ -1434,8 +1457,17 @@ const gameEntries: GameEntry[] = [
         name: 'ProtoCorgi',
         songSource: { songName: 'Leviathan 1', videoId: 'UzpRYgSCwds' },
     },
+    /*
+    Delta is a compilation, need to look into how to handle this more
+    {
+        name: 'Psyvariar Delta',
+        series: Series.Psyvariar,
+        songSource: { songName: 'Earth', videoId: '9Sa2ymKCQUI' },
+    },
+    */
     {
         name: 'Psyvariar 2',
+        series: Series.Psyvariar,
         songSource: { songName: 'Weakboson - Gorge City', videoId: 'wZrKXcoHkKw' },
     },
     {
@@ -1586,6 +1618,14 @@ const gameEntries: GameEntry[] = [
         name: 'Radirgy',
         series: Series.Radirgy,
         songSource: { songName: 'ukiha shopping mall', videoId: '_1QLg8TR4Oo' },
+    },
+    {
+        name: 'Radirgy 2',
+        series: Series.Radirgy,
+        songSource: [
+            { songName: 'Portable Tragedy', videoId: 'Gi7GSlmdpXE' },
+            { songName: 'Happy Fake', videoId: 'sqInLaqiQdY' },
+        ],
     },
     {
         name: 'Radirgy Swag',
@@ -2118,6 +2158,10 @@ const gameEntries: GameEntry[] = [
                 { source: 'Mega Drive', videoId: 'OfyvsPWS_yI' },
             ],
         },
+    },
+    {
+        name: 'Tempest 2000',
+        songSource: { songName: "Mind's Eye", videoId: 'ZdjlSWipbWM' },
     },
     {
         name: 'Tengai',

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export enum Series {
     Mahou = 'Mahou',
     Nanostray = 'Nanostray',
     OutZone = 'Out Zone',
+    Psyvariar = 'Psyvariar',
     RType = 'R-Type',
     Radirgy = 'Radirgy',
     Raiden = 'Raiden',


### PR DESCRIPTION
This pull request expands the `gameEntries` data in `src/data/games.ts` by adding several new games and their associated music tracks, as well as updating related enum definitions in `src/types.ts`. The changes primarily introduce new entries, support for additional series, and improvements to how certain games and their music are represented.

**New game entries and music tracks:**

* Added new games with their respective music tracks, including:
  - `Air Buster` (with arrangements for Arcade, Mega Drive, and PC Engine)
  - `Aka to Blue`
  - `Exceed 3rd - Jade Penetrate`
  - `Gyruss` (with arrangements for Arcade and NES)
  - `Radirgy 2` (with multiple tracks and series association)
  - `Tempest 2000`

**Series and enum updates:**

* Added `Psyvariar` to the `Series` enum in `src/types.ts` to support new and existing entries
* Associated `Psyvariar 2` with the `Series.Psyvariar` series

**Code comments and future work:**

* Added a comment and temporarily removed the `Psyvariar Delta` entry, noting that it is a compilation and may require special handling in the future