### PR TITLE
Add Viewpoint songs + more

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -1287,6 +1287,19 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Fin Fantasy', videoId: '80A7SNQFokU' },
     },
     {
+        name: 'Mr Heli',
+        alias: 'Battle Chopper',
+        songSource: {
+            songName: 'Theme',
+            arrangements: [
+                { source: 'Arcade', videoId: 'GqITupo_KG4' },
+                { source: 'Amstrad', videoId: 'z6GkfOo5RZ8' },
+                { source: 'Commodore 64', videoId: 'uHq3iH25VnY', startTime: 169, endTime: 299 },
+                { source: 'PC Engine', videoId: 'jauE6kBJbBY', startTime: 39, endTime: 157 },
+            ],
+        },
+    },
+    {
         name: 'Muchi Muchi Pork!',
         songSource: { songName: 'Doki Doki in the Sky', videoId: 'iTb0FEaqsv4' },
     },

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -2590,7 +2590,7 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Twinkle Star Sprites: La Petite Princesse',
         series: Series.TwinkleStarSprites,
-        songSource: { songName: 'Applicot Ground', videoId: '-feCSnMH9kHE' },
+        songSource: { songName: 'Applicot Ground', videoId: 'feCSnMH9kHE' },
     },
     {
         name: 'Tyrian',

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -1466,6 +1466,11 @@ const gameEntries: GameEntry[] = [
         name: 'ProtoCorgi',
         songSource: { songName: 'Leviathan 1', videoId: 'UzpRYgSCwds' },
     },
+    {
+        name: 'Psyvariar 2',
+        series: Series.Psyvariar,
+        songSource: { songName: 'Weakboson - Gorge City', videoId: 'wZrKXcoHkKw' },
+    },
     /*
     Delta is a compilation, need to look into how to handle this more
     {
@@ -1474,11 +1479,6 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Earth', videoId: '9Sa2ymKCQUI' },
     },
     */
-    {
-        name: 'Psyvariar 2',
-        series: Series.Psyvariar,
-        songSource: { songName: 'Weakboson - Gorge City', videoId: 'wZrKXcoHkKw' },
-    },
     {
         name: 'Pulstar',
         songSource: { songName: 'Front Line on the Earth', videoId: 'IexMUkiPg-M' },
@@ -2580,6 +2580,24 @@ const gameEntries: GameEntry[] = [
         name: 'Vasara 2',
         series: Series.Vasara,
         songSource: { songName: 'Like the Wind', videoId: '_Di0WbKOkHg' },
+    },
+    {
+        name: 'Viewpoint',
+        songSource: {
+            songName: 'Not All There',
+            arrangements: [
+                { source: 'Neo Geo', videoId: 'NUrSBCSGTiY' },
+                { source: 'Mega Drive', videoId: 'hW4oYFeUV-U' },
+                { source: 'Sharp X68000', videoId: 'nUzbmPTsmo4' },
+            ],
+        },
+    },
+    {
+        name: 'Viewpoint (PS1)',
+        songSource: {
+            songName: 'This Will Be Mine',
+            videoId: 'yV_kMe3I0og',
+        },
     },
     {
         name: 'Vimana',

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -357,6 +357,10 @@ const gameEntries: GameEntry[] = [
         ],
     },
     {
+        name: 'Crisis Wing',
+        songSource: { songName: 'URF!', videoId: 'p3TEz5Job74', startTime: 26, endTime: 126 },
+    },
+    {
         name: 'Cybattler',
         songSource: { songName: 'Interception', videoId: 'pZEdfyCUSmQ' },
     },
@@ -1293,7 +1297,7 @@ const gameEntries: GameEntry[] = [
             songName: 'Theme',
             arrangements: [
                 { source: 'Arcade', videoId: 'GqITupo_KG4' },
-                { source: 'Amstrad', videoId: 'z6GkfOo5RZ8' },
+                { source: 'Amstrad CPC', videoId: 'z6GkfOo5RZ8' },
                 { source: 'Commodore 64', videoId: 'uHq3iH25VnY', startTime: 169, endTime: 299 },
                 { source: 'PC Engine', videoId: 'jauE6kBJbBY', startTime: 39, endTime: 157 },
             ],
@@ -1495,14 +1499,6 @@ const gameEntries: GameEntry[] = [
         series: Series.Psyvariar,
         songSource: { songName: 'Weakboson - Gorge City', videoId: 'wZrKXcoHkKw' },
     },
-    /*
-    Delta is a compilation, need to look into how to handle this more
-    {
-        name: 'Psyvariar Delta',
-        series: Series.Psyvariar,
-        songSource: { songName: 'Earth', videoId: '9Sa2ymKCQUI' },
-    },
-    */
     {
         name: 'Pulstar',
         songSource: { songName: 'Front Line on the Earth', videoId: 'IexMUkiPg-M' },
@@ -1819,6 +1815,36 @@ const gameEntries: GameEntry[] = [
         name: 'Sagaia (Game Boy)',
         series: Series.Darius,
         songSource: { songName: 'Cosmic Air Way', videoId: 'ekMGtD9cDhQ' },
+    },
+    {
+        name: 'Saint Dragon',
+        songSource: {
+            songName: 'Metal Planet',
+            arrangements: [
+                {
+                    source: 'Arcade',
+                    videoId: '3no4tup4cvU',
+                },
+                {
+                    source: 'Amiga',
+                    videoId: '0GpVA06mWS8',
+                    endTime: 311,
+                },
+                {
+                    source: 'Amstrad CPC',
+                    videoId: '2cm1TycoaWI',
+                },
+                {
+                    source: 'Commodore 64',
+                    videoId: '_K5EcSVFY60',
+                },
+                {
+                    source: 'PC Engine',
+                    videoId: 'DCUd145hvlw',
+                    endTime: 251,
+                },
+            ],
+        },
     },
     {
         name: 'Salamander',
@@ -2729,6 +2755,15 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Stage 1, 3, 5', videoId: 'RXFcfd1oh4g', startTime: 2, endTime: 51 },
     },
 ];
+
+/*
+    Delta is a compilation, need to look into how to handle this more
+    {
+        name: 'Psyvariar Delta',
+        series: Series.Psyvariar,
+        songSource: { songName: 'Earth', videoId: '9Sa2ymKCQUI' },
+    },
+*/
 
 // Games without relevant YouTube links yet.
 // When a suitable YouTube video becomes available, replace '---' with the real videoId and move the entry into gameEntries above.

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -2585,7 +2585,7 @@ const gameEntries: GameEntry[] = [
     {
         name: 'Twinkle Star Sprites',
         series: Series.TwinkleStarSprites,
-        songSource: { songName: 'Applicot Ground', videoId: '-UpVxnCIfFca' },
+        songSource: { songName: 'Applicot Ground', videoId: '-UpVxnCIfFc' },
     },
     {
         name: 'Twinkle Star Sprites: La Petite Princesse',

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -2583,6 +2583,16 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Twin Flight', videoId: '4hG606bVSZU' },
     },
     {
+        name: 'Twinkle Star Sprites',
+        series: Series.TwinkleStarSprites,
+        songSource: { songName: 'Applicot Ground', videoId: '-UpVxnCIfFca' },
+    },
+    {
+        name: 'Twinkle Star Sprites: La Petite Princesse',
+        series: Series.TwinkleStarSprites,
+        songSource: { songName: 'Applicot Ground', videoId: '-feCSnMH9kHE' },
+    },
+    {
         name: 'Tyrian',
         songSource: { songName: 'Tyrian, the level', videoId: 'wNnTGbbDJfo' },
     },

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -373,6 +373,17 @@ const gameEntries: GameEntry[] = [
         songSource: { songName: 'Stage 1', videoId: 'vqi1eM9MNPw', startTime: 62, endTime: 213 },
     },
     {
+        name: 'Daioh Gale',
+        alias: ['Dezaemon', 'Dezaemon Plus'],
+        songSource: {
+            songName: 'Stage 1',
+            arrangements: [
+                { source: 'Dezaemon', videoId: 'hrgR5Fl2h5Y' },
+                { source: 'Dezaemon Plus', videoId: 'cdqGUeAtQUM' },
+            ],
+        },
+    },
+    {
         name: 'Dangerous Seed',
         songSource: {
             songName: '1st Tube',

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export enum Series {
     Touhou = 'Touhou Project',
     Truxton = 'Truxton',
     Twinbee = 'Twinbee',
+    TwinkleStarSprites = 'Twinkle Star Sprites',
     Vasara = 'Vasara',
     Zeal = 'Zeal',
     ZeroGunner = 'Zero Gunner',


### PR DESCRIPTION
This pull request adds several new game entries to the `gameEntries` array in `src/data/games.ts`, enriching the dataset with more games and their associated soundtrack information. It also makes a minor code cleanup by relocating a commented-out entry for `Psyvariar Delta` to the end of the file for better organization.

**New game entries and soundtrack enhancements:**

* Added `Crisis Wing` with its song "URF!" and specific start/end times.
* Added `Daioh Gale` (with aliases "Dezaemon" and "Dezaemon Plus") including multiple arrangements for "Stage 1".
* Added `Mr Heli` (alias "Battle Chopper") with multiple platform arrangements for its theme.
* Added `Saint Dragon` with "Metal Planet" and arrangements for Arcade, Amiga, Amstrad CPC, Commodore 64, and PC Engine.
* Added `Viewpoint` with arrangements for Neo Geo, Mega Drive, and Sharp X68000, and `Viewpoint (PS1)` with its own unique track.

**Code organization:**

* Moved the commented-out `Psyvariar Delta` entry to the end of the file, keeping the main game list clean and organized. [[1]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29L1469-L1476) [[2]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R2759-R2767)