### PR TITLE
Add perfect remix for Espgaluda

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -668,7 +668,10 @@ const gameEntries: GameEntry[] = [
         series: Series.Espgaluda,
         songSource: {
             songName: 'Bloody Separation ~ Bloody Arrival',
-            videoId: '5A6oJRZSFBg',
+            arrangements: [
+                { source: 'Original', videoId: '5A6oJRZSFBg' },
+                { source: 'Perfect Remix', videoId: 'ePAEJvHb_2Q' },
+            ],
         },
     },
     {


### PR DESCRIPTION
This pull request updates the `songSource` data structure for a game entry in `src/data/games.ts` to support multiple song arrangements instead of a single video ID.

**Data structure improvement:**

* Changed the `songSource` property for the relevant game entry to use an `arrangements` array, allowing multiple song versions (e.g., "Original" and "Perfect Remix") to be associated with the song, each with its own `videoId`.