### PR TITLE
Show unavailable songs in song list

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -2015,6 +2015,7 @@ const gameEntries: GameEntry[] = [
     },
     {
         name: 'Sonic Wings Special',
+        sortName: 'Sonic Wings 4',
         alias: ['Sonic Wings Limited', 'Aero Fighters Special'],
         series: Series.SonicWings,
         songSource: { songName: 'Japan stage', videoId: 'sXCTZsRJ6y8' },
@@ -2791,7 +2792,7 @@ const gameEntries: GameEntry[] = [
 
 // Games without relevant YouTube links yet.
 // When a suitable YouTube video becomes available, replace '---' with the real videoId and move the entry into gameEntries above.
-const _noSoundTrackGameEntries: NoSoundTrackGameEntry[] = [
+export const noSoundTrackGameEntries: NoSoundTrackGameEntry[] = [
     {
         name: 'Exzeal',
         series: Series.Zeal,
@@ -2799,6 +2800,7 @@ const _noSoundTrackGameEntries: NoSoundTrackGameEntry[] = [
     },
     {
         name: 'Sonic Wings Reunion',
+        sortName: 'Sonig Wings 5',
         alias: ['Aero Fighters Reunion'],
         series: Series.SonicWings,
         songSource: { songName: 'Abu Dhabi, UAE stage' },

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -2800,7 +2800,7 @@ export const noSoundTrackGameEntries: NoSoundTrackGameEntry[] = [
     },
     {
         name: 'Sonic Wings Reunion',
-        sortName: 'Sonig Wings 5',
+        sortName: 'Sonic Wings 5',
         alias: ['Aero Fighters Reunion'],
         series: Series.SonicWings,
         songSource: { songName: 'Abu Dhabi, UAE stage' },

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type SongEntry =
 
 export type SongEntryWithoutSoundtrack =
   | { songName: string }
-  | { songName: string; arrangements: [{ source: string }, ...{ source: string }[]] };
+  | { songName: string; arrangements: [Pick<SongArrangement, 'source'>, ...Pick<SongArrangement, 'source'>[]] };
 
 
 interface GameEntryBase {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,11 @@ export type SongEntry =
   | { songName: string; videoId: string; startTime?: number; endTime?: number }
   | { songName: string; arrangements: [SongArrangement, ...SongArrangement[]] };
 
+export type SongEntryWithoutSoundtrack =
+  | { songName: string }
+  | { songName: string; arrangements: [{ source: string }, ...{ source: string }[]] };
+
+
 interface GameEntryBase {
     name: string
     sortName?: string // optional override used for alphabetical sorting (e.g. 'Gradius 2' for 'Gradius II')
@@ -76,7 +81,7 @@ export type GameEntry = GameEntryBase & {
 export type GameEntryWithId = GameEntry & { id: number };
 
 export type NoSoundTrackGameEntry = GameEntryBase & {
-    songSource: { songName: string }
+    songSource: SongEntryWithoutSoundtrack
 };
 
 export type GameListEntry = { id: number; name: string; alias?: string | string[]; series?: Series };

--- a/src/views/SongListView.vue
+++ b/src/views/SongListView.vue
@@ -55,11 +55,25 @@
                                     <td>
                                         {{ song.songName }}
                                         <div class="d-sm-none mt-1">
-                                            <SongLinks :entry="song" />
+                                            <SongLinks
+                                                v-if="song.entry"
+                                                :entry="song.entry"
+                                            />
+                                            <span
+                                                v-else
+                                                class="icon-link text-secondary small"
+                                            ><i class="bi bi-youtube lh-1" /> Unavailable</span>
                                         </div>
                                     </td>
                                     <td class="text-nowrap d-none d-sm-table-cell">
-                                        <SongLinks :entry="song" />
+                                        <SongLinks
+                                            v-if="song.entry"
+                                            :entry="song.entry"
+                                        />
+                                        <span
+                                            v-else
+                                            class="icon-link text-secondary small"
+                                        ><i class="bi bi-youtube lh-1" /> Unavailable</span>
                                     </td>
                                 </tr>
                             </template>
@@ -82,31 +96,45 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
-import { games, totalSongs, totalShmups } from '@/data/games';
+import { games, noSoundTrackGameEntries, totalSongs, totalShmups } from '@/data/games';
 import type { SongEntry } from '@/data/games';
 import SongLinks from '@/components/SongLinks.vue';
 
 interface GameGroup {
     gameName: string
+    sortKey: string
     aliases: string[]
-    songs: SongEntry[]
+    songs: Array<{ songName: string; entry?: SongEntry }>
 }
 
 function normalizeAlias(alias: string | string[]): string[] {
-    if (Array.isArray(alias)) {
-        return alias;
-    }
-    return [alias];
+    return Array.isArray(alias) ? alias : [alias];
 }
 
-const gameGroups: GameGroup[] = games.map((game) => {
+const availableGroups: GameGroup[] = games.map((game) => {
     const sources = Array.isArray(game.songSource) ? game.songSource : [game.songSource];
     return {
         gameName: game.name,
+        sortKey: (game.sortName ?? game.name).toLowerCase(),
         aliases: game.alias ? normalizeAlias(game.alias) : [],
-        songs: sources,
+        songs: sources.map((entry) => ({ songName: entry.songName, entry })),
     };
 });
+
+const unavailableGroups: GameGroup[] = noSoundTrackGameEntries.map((game) => {
+    const source = game.songSource;
+    return {
+        gameName: game.name,
+        sortKey: (game.sortName ?? game.name).toLowerCase(),
+        aliases: game.alias ? normalizeAlias(game.alias) : [],
+        songs: 'arrangements' in source
+            ? source.arrangements.map(() => ({ songName: source.songName }))
+            : [{ songName: source.songName }],
+    };
+});
+
+const gameGroups: GameGroup[] = [...availableGroups, ...unavailableGroups]
+    .sort((a, b) => a.sortKey.localeCompare(b.sortKey));
 
 const hoveredGame = ref<string | null>(null);
 </script>


### PR DESCRIPTION
This pull request improves the handling and display of games without available soundtracks and enhances type safety in the codebase. The main changes include updating the data structure and type definitions for games lacking soundtrack links, exporting the relevant data for use in views, and updating the UI to clearly indicate when a song's soundtrack is unavailable.

**Data structure and type improvements:**

* Introduced a new `SongEntryWithoutSoundtrack` type and updated the `NoSoundTrackGameEntry` type to use this for better type safety and clarity in representing games without soundtrack links. (`src/types.ts` [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR64-R68) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL79-R84)
* Added or corrected `sortName` fields for "Sonic Wings Special" and "Sonic Wings Reunion" to improve sorting and display consistency. (`src/data/games.ts` [[1]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29R2018) [[2]](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29L2794-R2803)

**Data export and usage:**

* Changed the previously internal `_noSoundTrackGameEntries` to an exported `noSoundTrackGameEntries` array, making it available for use in views and other modules. (`src/data/games.ts` [src/data/games.tsL2794-R2803](diffhunk://#diff-7edbcb0b011bb56cb56d1c7d0850aa252155cc8262d139adbc4bdbdfeded3e29L2794-R2803))

**UI and display improvements:**

* Updated `SongListView.vue` to group both available and unavailable games, sort them properly, and display an "Unavailable" indicator (with icon) when a song has no associated soundtrack link, primarily for use when a Youtube link is removed without substitute available. (`src/views/SongListView.vue` [[1]](diffhunk://#diff-aaec250f216e41a834bd8934dcb1e157056668020f271046f5d4576df66895a6L58-R76) [[2]](diffhunk://#diff-aaec250f216e41a834bd8934dcb1e157056668020f271046f5d4576df66895a6L85-R138)