### PR TITLE
Fixes to R-Type songs

### DIFF
--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -1539,12 +1539,6 @@ const gameEntries: GameEntry[] = [
                     videoId: '42xjbdXze8E',
                 },
                 {
-                    source: 'Amstrad CPC',
-                    videoId: 'TUqxvufguZY',
-                    startTime: 270,
-                    endTime: 321,
-                },
-                {
                     source: 'Atari ST',
                     videoId: 'B-xGUTHedU0',
                     startTime: 50,

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -1611,7 +1611,19 @@ const gameEntries: GameEntry[] = [
         name: 'R-Type III: The Third Lightning',
         sortName: 'R-Type 3: The Third Lightning',
         series: Series.RType,
-        songSource: { songName: 'Catapult Dimension', videoId: 'EsLgLrM2CbY' },
+        songSource: {
+            songName: 'Outer Space',
+            arrangements: [
+                {
+                    source: 'Original',
+                    videoId: 'EsLgLrM2CbY',
+                },
+                {
+                    source: 'Dimensions',
+                    videoId: 'bK7gkCTRdaw',
+                },
+            ],
+        },
     },
     {
         name: 'R-Type Delta',


### PR DESCRIPTION
- Remove Amstrad arrangement for R-Type 1, video has been removed without suitable replacement
- Fix R-Type III song title: Should be Outer Space, not Catapult DImensions
- Add R-Type Dimensions III arrangement of Outer Space